### PR TITLE
Configurando importação de React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules/**
 .cache/
 public
 src/gatsby-types.d.ts

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -9,7 +9,7 @@ const config: GatsbyConfig = {
   // If you use VSCode you can also use the GraphQL plugin
   // Learn more at: https://gatsby.dev/graphql-typegen
   graphqlTypegen: true,
-  plugins: ["gatsby-plugin-image", "gatsby-plugin-sitemap", "gatsby-plugin-sharp", "gatsby-transformer-sharp", {
+  plugins: ["gatsby-plugin-image", "gatsby-plugin-sitemap", "gatsby-plugin-sharp", "gatsby-transformer-sharp", "gatsby-plugin-provide-react", {
     resolve: 'gatsby-source-filesystem',
     options: {
       "name": "images",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "gatsby": "^5.11.0",
     "gatsby-plugin-image": "^3.11.0",
+    "gatsby-plugin-provide-react": "^1.0.2",
     "gatsby-plugin-sharp": "^5.11.0",
     "gatsby-plugin-sitemap": "^6.11.0",
     "gatsby-source-filesystem": "^5.11.0",

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { Link, HeadFC, PageProps } from "gatsby"
 
 const pageStyles = {
@@ -23,7 +22,7 @@ const codeStyles = {
   borderRadius: 4,
 }
 
-const NotFoundPage: React.FC<PageProps> = () => {
+const NotFoundPage = ({}: PageProps) => {
   return (
     <main style={pageStyles}>
       <h1 style={headingStyles}>Page not found</h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import type { HeadFC, PageProps } from "gatsby"
 
 const pageStyles = {
@@ -136,7 +135,7 @@ const links = [
   },
 ]
 
-const IndexPage: React.FC<PageProps> = () => {
+const IndexPage = ({}: PageProps) => {
   return (
     <main style={pageStyles}>
       <h1 style={headingStyles}>
@@ -190,4 +189,4 @@ const IndexPage: React.FC<PageProps> = () => {
 
 export default IndexPage
 
-export const Head: HeadFC = () => <title>Home Page</title>
+export const Head = ({}: HeadFC) => <title>Home Page</title>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "dom",
       "esnext"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-    "jsx": "react" /* Specify what JSX code is generated. */,
+    "jsx": "react-jsx" /* Specify what JSX code is generated. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5185,6 +5185,11 @@ gatsby-plugin-page-creator@^5.11.0:
     globby "^11.1.0"
     lodash "^4.17.21"
 
+gatsby-plugin-provide-react@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-provide-react/-/gatsby-plugin-provide-react-1.0.2.tgz#e50bb311cd8ef5855c6d94f708266ab117c77a15"
+  integrity sha512-Zkbs0uiniXDvtGT86+bTCdj0cuT9REpGJxJTIKLQJW3AvmAdh/MAMwWzMdyMrX1cwjqDPZBFC7bw7A49iP/fyw==
+
 gatsby-plugin-sharp@^5.11.0:
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.11.0.tgz#4a030293278bf7f3869e55536aed011f6008e45b"


### PR DESCRIPTION
Removendo a necessidade de importar o `React` em todos os arquivos:
- usando `gatsby-plugin-provide-react`
- atualizando o `jsx` no arquivo `tsconfig`
- atualizando código padrão para condizer com a nova forma de criar componentes (sem `React.`).